### PR TITLE
Add support for OMS_PATH in node-events

### DIFF
--- a/test/runner.js
+++ b/test/runner.js
@@ -17,16 +17,19 @@ const payloads = JSON.parse(readFileSync(payloadFile));
 // get additional CLI arguments from the payload file name
 const actions = basename(payloadFile).split('.')[0].split('_');
 
+const OMS_PATH = process.env.OMS_PATH || null
+
 function test(cb) {
-  const args = ['oms', 'subscribe', '--silent', 'listen', ...actions];
+  let oms
+  const args = ['subscribe', '--silent', 'listen', ...actions];
   console.log(`Spawn: ${args.join(' ')}`);
-  const oms = spawn('npx', args);
-  oms.stdout.on('data', (data) => {
-    process.stdout.write(data);
-  });
-  oms.stderr.on('data', (data) => {
-    process.stdout.write(data);
-  });
+  if (OMS_PATH) {
+    oms = spawn(OMS_PATH, args)
+  } else {
+    oms = spawn('npx', ['oms'].concat(args))
+  }
+  oms.stdout.pipe(process.stdout)
+  oms.stderr.pipe(process.stderr)
   cb(oms);
 }
 


### PR DESCRIPTION
Currently the test runner makes use of `npx`, which means it'll always use the npm-published version, which does not let us test this on everyday builds of CI since it'll only test against the published version

This PR adds support for `OMS_PATH` so test runner can specify it's own OMS path that bypasses `npx`